### PR TITLE
 Add option to disable vibration during calls 

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
 
   <uses-permission android:name="android.permission.VIBRATE" />
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+  <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 
   <application
       android:allowBackup="true"

--- a/src/main/java/com/jmstudios/chibe/state/SettingsModel.java
+++ b/src/main/java/com/jmstudios/chibe/state/SettingsModel.java
@@ -39,6 +39,7 @@ public class SettingsModel {
     public static final String mCustomHourVibrationPatternPrefKey = "pref_key_custom_hour_vibration_pattern";
     public static final String mDarkThemePrefKey = "pref_key_dark_theme";
     public static final String mVibrateDuringDndPrefKey = "pref_key_vibrate_during_dnd";
+    public static final String mVibrateDuringCallsPrefKey = "pref_key_vibrate_during_calls";
 
     private SharedPreferences mSharedPrefs;
 
@@ -81,6 +82,11 @@ public class SettingsModel {
     public boolean shouldVibrateDuringDnd() {
         return mSharedPrefs.getBoolean
             (mVibrateDuringDndPrefKey, true);
+    }
+
+    public boolean shouldVibrateDuringCalls() {
+        return mSharedPrefs.getBoolean
+            (mVibrateDuringCallsPrefKey, true);
     }
 
     public boolean isIntroShown() {

--- a/src/main/java/com/jmstudios/chibe/timing/VibrationAlarmReceiver.java
+++ b/src/main/java/com/jmstudios/chibe/timing/VibrationAlarmReceiver.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import android.os.Vibrator;
 import android.app.NotificationManager;
 import android.annotation.TargetApi;
+import android.telephony.TelephonyManager;
 
 import com.jmstudios.chibe.state.SettingsModel;
 
@@ -70,7 +71,8 @@ public class VibrationAlarmReceiver extends BroadcastReceiver {
                                   Context context) {
         boolean vibrate = true;
 
-        if (!settingsModel.shouldVibrateDuringDnd() && isDndEnabled(context)){
+        if ( (!settingsModel.shouldVibrateDuringDnd() && isDndEnabled(context)) ||
+             (!settingsModel.shouldVibrateDuringCalls() && isCallActive(context))){
             vibrate = false;
         }
 
@@ -104,6 +106,18 @@ public class VibrationAlarmReceiver extends BroadcastReceiver {
         }
 
         return dndIsEnabled;
+    }
+
+    private boolean isCallActive(Context context){
+        boolean activeCall = true;
+        TelephonyManager telephonyManager = (TelephonyManager)
+            context.getSystemService(Context.TELEPHONY_SERVICE);
+
+        if(telephonyManager.getCallState() == telephonyManager.CALL_STATE_IDLE){
+            activeCall = false;
+        }
+
+        return activeCall;
     }
 
     // Vibrates the normal pattern `ammNormalPattern` times and the

--- a/src/main/java/com/jmstudios/chibe/timing/VibrationAlarmReceiver.java
+++ b/src/main/java/com/jmstudios/chibe/timing/VibrationAlarmReceiver.java
@@ -68,34 +68,40 @@ public class VibrationAlarmReceiver extends BroadcastReceiver {
 
     private boolean shouldVibrate(SettingsModel settingsModel,
                                   Context context) {
-        boolean dndIsSupported = android.os.Build.VERSION.SDK_INT >= 23;
-        if (dndIsSupported && isDndEnabled(context)) {
-            return settingsModel.shouldVibrateDuringDnd();
-        } else {
-            return true;
+        boolean vibrate = true;
+
+        if (!settingsModel.shouldVibrateDuringDnd() && isDndEnabled(context)){
+            vibrate = false;
         }
+
+        return vibrate;
     }
 
     @TargetApi(23)
     private boolean isDndEnabled(Context context) {
-        NotificationManager notificationManager = (NotificationManager)
-            context.getSystemService(Context.NOTIFICATION_SERVICE);
-        if (notificationManager == null) return false;
+        boolean dndIsEnabled = false;
+        boolean dndIsSupported = android.os.Build.VERSION.SDK_INT >= 23;
 
-        int currentFilter =
-            notificationManager.getCurrentInterruptionFilter();
+        if(dndIsSupported){
+            NotificationManager notificationManager = (NotificationManager)
+                context.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (notificationManager == null) return false;
 
-        // All other values indicate an active Dnd filter. See:
-        // https://developer.android.com/reference/android/app/NotificationManager.html#INTERRUPTION_FILTER_ALARMS
-        boolean dndIsEnabled = currentFilter !=
-            NotificationManager.INTERRUPTION_FILTER_ALL &&
-            currentFilter !=
-            NotificationManager.INTERRUPTION_FILTER_UNKNOWN;
+            int currentFilter =
+                notificationManager.getCurrentInterruptionFilter();
 
-        if (DEBUG) Log.i(TAG, "Dnd is " +
-                         (dndIsEnabled ? "enabled" : "disabled"));
-        if (DEBUG) Log.i(TAG, String.format
-                         ("Filter number is %d.", currentFilter));
+            // All other values indicate an active Dnd filter. See:
+            // https://developer.android.com/reference/android/app/NotificationManager.html#INTERRUPTION_FILTER_ALARMS
+            dndIsEnabled = currentFilter !=
+                NotificationManager.INTERRUPTION_FILTER_ALL &&
+                currentFilter !=
+                NotificationManager.INTERRUPTION_FILTER_UNKNOWN;
+
+            if (DEBUG) Log.i(TAG, "Dnd is " +
+                             (dndIsEnabled ? "enabled" : "disabled"));
+            if (DEBUG) Log.i(TAG, String.format
+                             ("Filter number is %d.", currentFilter));
+        }
 
         return dndIsEnabled;
     }

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -57,6 +57,9 @@
   <string name="vibrate_during_dnd_preference_summary">Lets Chibe
   vibrate even if your phone\'s Do Not Disturb mode is
   enabled.</string>
+  <string name="vibrate_during_calls_preference_title">Vibrate during calls</string>
+  <string name="vibrate_during_calls_preference_summary">Lets Chibe vibrate
+  while making a call</string>
 
   <string name="pref_category_vibration">Vibration patterns</string>
   <string name="test_normal_vibration_preference_title">Test base

--- a/src/main/res/xml/preferences.xml
+++ b/src/main/res/xml/preferences.xml
@@ -33,6 +33,13 @@
         android:key="pref_key_sleep_end"
         android:title="@string/sleep_end_preference_title"
         android:defaultValue="09:00" />
+
+    <SwitchPreference
+        android:key="pref_key_vibrate_during_calls"
+        android:title="@string/vibrate_during_calls_preference_title"
+        android:summary="@string/vibrate_during_calls_preference_summary"
+        android:defaultValue="false" />
+
   </PreferenceCategory>
 
   <PreferenceCategory android:title="@string/pref_category_vibration">


### PR DESCRIPTION
In these commits:

- I made shouldVibrate() more generic, so other checks can be made as well. For this I had to move some of the DnD-specific functionality (API check) in isDndEnabled(), so now only isDndEnabled() is responsible for implementing that feature
- I added an option to enable/disable vibrations during calls. (Note, of course, that in order to do this I had to add the appropriate permission)
